### PR TITLE
Fix list encoding

### DIFF
--- a/core/src/main/java/dev/ahmedmourad/bundlizer/BundleEncoder.kt
+++ b/core/src/main/java/dev/ahmedmourad/bundlizer/BundleEncoder.kt
@@ -47,14 +47,14 @@ internal class BundleEncoder(
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {
-
-        if (keyInParent.isNullOrBlank()) {
-            return
-        }
-
+        
         if (descriptor.kind in arrayOf(StructureKind.LIST, StructureKind.MAP)) {
             val size = key.toIntOrNull()?.let { it + 1 } ?: 0
             bundle.putInt("\$size", size)
+        }
+        
+        if (keyInParent.isNullOrBlank()) {
+            return
         }
 
         parentBundle?.putBundle(keyInParent, bundle)


### PR DESCRIPTION
### Problem: 

In current version, encoding of top level List structure can't be decoded because don't contains `size` field. 

#### Example: 
```kotlin
// Exists items in adapter. 
val bundle = adapter.items.bundle(ListSerializer(Item.serializer()))

val items = state.unbundle(ListSerializer(Item.serializer()))
// items size = 0
```

### Solution: 
Moved adding `size` key to before `keyInParent` to fix issue. I don't sure what nothing was not broken by this change, please verify solution.